### PR TITLE
Add setup and cleanup commands, improve overwrite handling, and update docs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+- show versions in tree (because append only)
+- add metadata when seeding
+- show metadata in tree
+- show metadata when filling/overwriting
+- add 

--- a/cmd/vault-envrc-generator/main.go
+++ b/cmd/vault-envrc-generator/main.go
@@ -132,5 +132,13 @@ func main() {
 		cobra.CheckErr(err)
 	}
 
+	if rtc, err := appcmds.NewRmTreeCommand(); err == nil {
+		cmd, err := cli.BuildCobraCommand(rtc, opts...)
+		cobra.CheckErr(err)
+		rootCmd.AddCommand(cmd)
+	} else {
+		cobra.CheckErr(err)
+	}
+
 	cobra.CheckErr(rootCmd.Execute())
 }

--- a/cmds/batch.go
+++ b/cmds/batch.go
@@ -30,6 +30,7 @@ type BatchSettings struct {
 	Jobs            []string `glazed.parameter:"jobs"`
 	Sections        []string `glazed.parameter:"sections"`
 	ForceOverwrite  bool     `glazed.parameter:"force-overwrite"`
+	SkipUnreadable  bool     `glazed.parameter:"skip-unreadable"`
 }
 
 func NewBatchCommand() (*BatchCommand, error) {
@@ -52,6 +53,7 @@ func NewBatchCommand() (*BatchCommand, error) {
 			parameters.NewParameterDefinition("jobs", parameters.ParameterTypeStringList, parameters.WithHelp("Only process jobs with these names; default all")),
 			parameters.NewParameterDefinition("sections", parameters.ParameterTypeStringList, parameters.WithHelp("Only process sections with these names; default all")),
 			parameters.NewParameterDefinition("force-overwrite", parameters.ParameterTypeBool, parameters.WithDefault(false), parameters.WithHelp("Overwrite .envrc without prompting")),
+			parameters.NewParameterDefinition("skip-unreadable", parameters.ParameterTypeBool, parameters.WithDefault(false), parameters.WithHelp("Skip sections that cannot be read; warn instead of failing")),
 		),
 		gcmds.WithLayersList(layer),
 	)
@@ -132,13 +134,14 @@ func (c *BatchCommand) Run(ctx context.Context, parsed *glayers.ParsedLayers) er
 	}
 	proc := batch.Processor{Client: client}
 	return proc.Process(cfg, batch.ProcessorOptions{
-		BasePath:        s.BasePath,
-		OutputOverride:  s.OutputOverride,
-		FormatOverride:  s.Format,
-		ContinueOnError: s.ContinueOnError,
-		DryRun:          s.DryRun,
-		SortKeys:        s.SortKeys,
-		ForceOverwrite:  s.ForceOverwrite,
+		BasePath:               s.BasePath,
+		OutputOverride:         s.OutputOverride,
+		FormatOverride:         s.Format,
+		ContinueOnError:        s.ContinueOnError,
+		DryRun:                 s.DryRun,
+		SortKeys:               s.SortKeys,
+		ForceOverwrite:         s.ForceOverwrite,
+		SkipUnreadableSections: s.SkipUnreadable,
 	})
 }
 

--- a/cmds/rmtree.go
+++ b/cmds/rmtree.go
@@ -1,0 +1,122 @@
+package cmds
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	glzcli "github.com/go-go-golems/glazed/pkg/cli"
+	gcmds "github.com/go-go-golems/glazed/pkg/cmds"
+	glayers "github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-go-golems/vault-envrc-generator/pkg/listing"
+	"github.com/go-go-golems/vault-envrc-generator/pkg/vault"
+	"github.com/go-go-golems/vault-envrc-generator/pkg/vaultlayer"
+)
+
+func askForConfirmation(prompt string) bool {
+	fmt.Print(prompt)
+	var line string
+	_, _ = fmt.Scanln(&line)
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+type RmTreeCommand struct{ *gcmds.CommandDescription }
+
+type RmTreeSettings struct {
+	Path  string `glazed.parameter:"path"`
+	Depth int    `glazed.parameter:"depth"`
+	Yes   bool   `glazed.parameter:"yes"`
+}
+
+func NewRmTreeCommand() (*RmTreeCommand, error) {
+	layer, err := glzcli.NewCommandSettingsLayer()
+	if err != nil {
+		return nil, err
+	}
+	cd := gcmds.NewCommandDescription(
+		"rm-tree",
+		gcmds.WithShort("Print a Vault tree and delete all leaves under it after confirmation"),
+		gcmds.WithFlags(
+			parameters.NewParameterDefinition("path", parameters.ParameterTypeString, parameters.WithRequired(true), parameters.WithShortFlag("p"), parameters.WithHelp("Root Vault path to delete")),
+			parameters.NewParameterDefinition("depth", parameters.ParameterTypeInteger, parameters.WithDefault(0), parameters.WithHelp("Max depth to scan before delete (0 = unlimited)")),
+			parameters.NewParameterDefinition("yes", parameters.ParameterTypeBool, parameters.WithDefault(false), parameters.WithHelp("Skip confirmation prompt and delete immediately")),
+		),
+		gcmds.WithLayersList(layer),
+	)
+	_, err = vaultlayer.AddVaultLayerToCommand(cd)
+	if err != nil {
+		return nil, err
+	}
+	return &RmTreeCommand{cd}, nil
+}
+
+func (c *RmTreeCommand) Run(ctx context.Context, parsed *glayers.ParsedLayers) error {
+	s := &RmTreeSettings{}
+	if err := parsed.InitializeStruct(glayers.DefaultSlug, s); err != nil {
+		return err
+	}
+	vs, err := vaultlayer.GetVaultSettings(parsed)
+	if err != nil {
+		return err
+	}
+
+	ctx2, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	token, err := vault.ResolveToken(ctx2, vs.VaultToken, vault.TokenSource(vs.VaultTokenSource), vs.VaultTokenFile, false)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Vault token: %w", err)
+	}
+	client, err := vault.NewClient(vs.VaultAddr, token)
+	if err != nil {
+		return fmt.Errorf("failed to create Vault client: %w", err)
+	}
+
+	// Print the tree (list of paths)
+	keys, errs := listing.Walk(client, s.Path, s.Depth)
+	out := map[string]interface{}{"paths": keys}
+	enc := yaml.NewEncoder(os.Stdout)
+	enc.SetIndent(2)
+	_ = enc.Encode(out)
+	_ = enc.Close()
+	for _, e := range errs {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", e)
+	}
+	if len(keys) == 0 {
+		fmt.Fprintln(os.Stderr, "nothing to delete")
+		return nil
+	}
+
+	if !s.Yes {
+		if !askForConfirmation(fmt.Sprintf("Delete %d secrets under '%s'? [y/N]: ", len(keys), s.Path)) {
+			fmt.Fprintln(os.Stderr, "aborted")
+			return nil
+		}
+	}
+
+	// Delete leaf secrets (skip directories)
+	deleted := 0
+	for _, p := range keys {
+		if strings.HasSuffix(p, "/") {
+			continue
+		}
+		if err := client.DeleteSecret(p); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to delete %s: %v\n", p, err)
+		} else {
+			deleted++
+		}
+	}
+	fmt.Fprintf(os.Stdout, "deleted %d secrets\n", deleted)
+	return nil
+}
+
+var _ gcmds.BareCommand = &RmTreeCommand{}

--- a/pkg/seed/runner.go
+++ b/pkg/seed/runner.go
@@ -205,7 +205,9 @@ func Run(client *vault.Client, spec *Spec, opts Options) error {
 							continue
 						}
 						if !commandAllRun {
-							prompt := fmt.Sprintf("Run setup command '%s' at '%s'? [y/N/a/s]: %s ", k, renderedTarget, cmdStr)
+							escapedRenderedTarget := strings.ReplaceAll(renderedTarget, `\`, `\\`)
+							escapedRenderedTarget = strings.ReplaceAll(escapedRenderedTarget, "'", "\\'")
+							prompt := fmt.Sprintf("Run setup command '%s' at '%s'? [y/N/a/s]: %s ", k, escapedRenderedTarget, cmdStr)
 							dec := askForDecision(prompt)
 							switch dec {
 							case decYes:

--- a/pkg/seed/spec.go
+++ b/pkg/seed/spec.go
@@ -6,13 +6,16 @@ type Spec struct {
 }
 
 type Set struct {
-	Name      string                       `yaml:"name,omitempty"`
-	Path      string                       `yaml:"path"`
-	Data      map[string]string            `yaml:"data"`
-	Env       map[string]string            `yaml:"env"`
-	Files     map[string]string            `yaml:"files"`
-	JsonFiles map[string]JsonFileTransform `yaml:"json_files"`
-	YamlFiles map[string]YamlFileTransform `yaml:"yaml_files"`
+	Name            string                       `yaml:"name,omitempty"`
+	Path            string                       `yaml:"path"`
+	Data            map[string]string            `yaml:"data"`
+	Env             map[string]string            `yaml:"env"`
+	Files           map[string]string            `yaml:"files"`
+	Commands        map[string]string            `yaml:"commands"`
+	SetupCommands   map[string]string            `yaml:"setup_commands"`
+	CleanupCommands []string                     `yaml:"cleanup_commands"`
+	JsonFiles       map[string]JsonFileTransform `yaml:"json_files"`
+	YamlFiles       map[string]YamlFileTransform `yaml:"yaml_files"`
 }
 
 // JsonFileTransform defines how to extract and transform data from JSON files

--- a/pkg/vault/context.go
+++ b/pkg/vault/context.go
@@ -9,6 +9,8 @@ import (
 // TemplateContext used for rendering templated strings such as paths
 type TemplateContext struct {
 	Token TokenContext
+	Extra map[string]interface{}
+	Data  map[string]interface{}
 }
 
 type TokenContext struct {


### PR DESCRIPTION
- Introduce `setup_commands` and `cleanup_commands` in seed specifications.
- Implement `rmtree` command to visualize and delete Vault paths with confirmation.
- Add `--skip-unreadable` option to batch commands to skip unreadable sections.
- Enhance `--force` flag functionality to allow overwriting existing keys without 
  confirmation.
- Introduce `--allow-commands` flag to execute commands in specs without 
  confirmation.
- Update documentation to reflect new features and improved command options.